### PR TITLE
Implement server-persisted to-do list with Supabase backend

### DIFF
--- a/.agents/skills/front-end/SKILL.md
+++ b/.agents/skills/front-end/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: front-end
+description: Use when implementing UI changes: components, pages, client state/composables, routes, styles, or frontend tests.
+---
+
+# Front-End
+
+Overview
+--------
+Guidance and checklist for front-end work. Use this skill when making changes that affect the UI surface, client-side state, routing, styling, or frontend tests. Keep changes small, testable, and well-documented.
+
+When to Use
+-----------
+- Use when adding or modifying components, layouts, pages, client composables/stores, or frontend test coverage.
+- Use when integrating UI with new or changed API routes that the client depends on.
+- Do NOT use for purely backend maintenance unrelated to the UI.
+
+Core Patterns
+-------------
+- Prefer small composables for client state (e.g., `useXStore()`) over large class-based singletons.
+- Extract complex logic from components into composables/services to keep templates concise.
+- Surface loading, disabled and error states; make controls accessible and keyboard friendly.
+- Use stable keys for lists (e.g., `:key="id"`) and avoid text-based keys.
+- Centralize API calls and document request/response shapes; handle 4xx/5xx failures gracefully.
+- Add unit tests for composables and key component logic; add E2E tests for cross-component flows.
+
+How to Apply (Checklist)
+-----------------------
+1. Add/modify a composable for client state and centralize fetch/update logic.
+2. Wire components to composables via props or imports; avoid deep prop drilling.
+3. Add loading/error UI and accessibility attributes; disable actions during requests.
+4. Add unit tests (Vitest + happy-dom) for the composable and critical component behavior.
+5. Run `npm run typecheck`, `npx eslint .`, and `npm run test:unit` before merging.
+6. If routes/pages changed, run E2E checks or manual QA of the full user flows.
+
+Quick File Targets
+------------------
+- Components: `layers/*/components/**/*.vue`
+- Pages: `layers/*/pages/**/*.vue`
+- Client state/composables: `layers/*/utils/*.ts` or `layers/*/composables/*`
+- API routes (when relevant): `server/api/**`
+- Tests: `layers/**/tests/unit/**` and `tests/e2e/**`
+
+Common Pitfalls
+---------------
+- Breaking imports by renaming/moving components without updating consumers.
+- Using unstable list keys causing rendering issues.
+- Not handling optimistic UI or failure rollbacks.
+
+Verification
+------------
+- Run `npm run typecheck`, `npx eslint .`, `npm run test:unit`; run E2E or manual QA for multi-component flows.
+- Smoke test key flows: create/edit/delete, keyboard navigation, responsive behavior.

--- a/docs/plans/2026-03-16-to-do-plan.md
+++ b/docs/plans/2026-03-16-to-do-plan.md
@@ -89,6 +89,29 @@ Implementation Steps
 6. Wire edit flow: clicking Edit populates the form, submitting performs a PUT to the API, and the store updates locally on success.
 7. Add unit tests for the store (mock fetch/Supabase) and run `npm run test:unit`.
 
+API Contract Examples
+---------------------
+- `GET /api/todos` → 200 OK
+  - Response: `[{ id, text, done, created_at, updated_at }, ...]`
+- `POST /api/todos` → 201 Created or 409 Conflict
+  - Request body: `{ "text": "Buy milk" }`
+  - Success response: `201 Created` with body `{ id, text, done, created_at, updated_at }`
+  - Limit reached: `409 Conflict` with body `{ "error": "todo limit reached" }`
+- `PUT /api/todos/:id` → 200 OK or 404 Not Found
+  - Request body: `{ "text": "Updated", "done": true }` (partial allowed)
+  - Success response: `200 OK` with updated todo
+- `DELETE /api/todos/:id` → 204 No Content or 404 Not Found (optional)
+
+DB Migration / Extension Note
+---------------------------
+- The schema uses `gen_random_uuid()` for UUID defaults. Ensure the pgcrypto extension (or the appropriate UUID generator) is enabled in Supabase before running the migration, for example:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+```
+
+Add this to your migration script or provisioning steps so `gen_random_uuid()` is available.
+
 Verification / Manual QA
 -----------------------
 - Commands:

--- a/docs/plans/2026-03-16-to-do-plan.md
+++ b/docs/plans/2026-03-16-to-do-plan.md
@@ -13,9 +13,9 @@ Chosen Approach
 High-level Architecture
 -----------------------
 - Server
-  - `layers/to-do/server/services/storage.ts`: Supabase-backed storage helper that mirrors the pattern in `layers/pomodoro/server/services/storage.ts`. It should expose `load(credentialsId?)`, `save(todo, credentialsId?)`, `update(todo, credentialsId?)`, and `remove(id, credentialsId?)` functions.
+  - `layers/to-do/server/services/storage.ts`: Supabase-backed storage helper that mirrors the pattern in `layers/pomodoro/server/services/storage.ts`. It should expose `load()`, `save(todo)`, `update(todo)`, and `remove(id)` functions.
   - API routes under `server/api/todos*`:
-    - `todos.get.ts` — GET all todos (optionally filtered by credential/user)
+    - `todos.get.ts` — GET all todos
     - `todos.post.ts` — POST create todo
     - `todos/[id].put.ts` — PUT update todo
     - (optional) `todos/[id].delete.ts` — DELETE todo
@@ -26,13 +26,12 @@ High-level Architecture
 
 Data Model (Supabase / Postgres)
 --------------------------------
-Provide this SQL when provisioning the database (you said you'll create it). Suggested schema:
+Provide this SQL when provisioning the database (you said you'll create it). Suggested schema for a public to-do list (no credentials):
 
 ```sql
--- Postgres / Supabase schema for the `todos` table
+-- Postgres / Supabase schema for the `todos` table (public list, no credentials)
 CREATE TABLE todos (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  credential_id uuid NOT NULL,
   text text NOT NULL,
   done boolean NOT NULL DEFAULT false,
   created_at timestamptz NOT NULL DEFAULT now(),
@@ -54,7 +53,11 @@ FOR EACH ROW
 EXECUTE PROCEDURE trigger_set_timestamp();
 ```
 
-Notes: use `credential_id` to scope tasks to a user or credential; adjust nullability if you want anonymous lists.
+Notes: this table is for a public to-do list (no credential_id). If you later add multi-user support, add a `credential_id` column.
+
+Limit requirement
+-----------------
+- The server must enforce a maximum of 100 to-do items. Attempting to create a new todo when the total count is >= 100 should return a 400-level error (e.g., 409 Conflict or 400 Bad Request) with a clear message. The storage helper's `save` function should check the current count before inserting.
 
 Files To Create / Modify
 -------------------------
@@ -74,7 +77,12 @@ Modify (client):
 Implementation Steps
 --------------------
 1. Implement Supabase-backed storage helper in `layers/to-do/server/services/storage.ts` using the existing helper pattern (call `useProductivitySupabaseClient()` or a `useToDoSupabaseClient()` wrapper).
+   - `save(todo)`: before inserting, query the count `SELECT COUNT(*) FROM todos` and return an error if >= 100.
+   - `load()`: fetch todos ordered by `done ASC, created_at ASC` (pending first).
+   - `update(todo)`: update text/done fields, return updated record.
+   - `remove(id)`: delete a todo.
 2. Implement server API routes that call the storage helper: `GET /api/todos`, `POST /api/todos`, `PUT /api/todos/:id`, and optional `DELETE /api/todos/:id`.
+   - `POST /api/todos` should return 409 or 400 when the 100-item limit is reached.
 3. Replace the class-based store with `useTaskStore()` composable that calls the API routes and keeps `items` reactive.
 4. Update `ToDoTaskForm.vue` to support create/edit modes and adjust styles to be full-width; wire submit to call the store's `add` or `saveEditing`.
 5. Update `ToDoTaskList.vue` to display "Pending" and "Completed" sections with headings, use `task.id` as `:key`, and add an Edit action that populates the form.

--- a/docs/plans/2026-03-16-to-do-plan.md
+++ b/docs/plans/2026-03-16-to-do-plan.md
@@ -1,0 +1,76 @@
+# To-Do App: Implementation Plan
+
+Date: 2026-03-16
+
+Goal
+----
+- Implement server-persisted TODOs using SQLite; provide a full-width input that supports creating and editing tasks; show Pending (top) and Completed (below) sections with headings.
+
+Chosen Approach
+---------------
+- Use SQLite via `better-sqlite3` on the server (`server/` routes) for durable storage and simple SQL CRUD.
+
+High-level Architecture
+-----------------------
+- Server
+  - `server/db/todos.ts`: DB helper opening `server/data/todos.sqlite`, ensuring table exists, and exposing CRUD functions.
+  - API routes under `server/api/todos*`:
+    - `todos.get.ts` — GET all todos
+    - `todos.post.ts` — POST create todo
+    - `todos/[id].put.ts` — PUT update todo
+    - (optional) `todos/[id].delete.ts` — DELETE todo
+- Client
+  - `layers/to-do/utils/store.ts`: composable `useTaskStore()` that holds reactive `items` and methods `load()`, `add()`, `update()`, `toggleDone()`, `setEditing()`, `saveEditing()` and syncs with server via `$fetch`.
+  - `ToDoTaskForm.vue`: full-width input, supports create and edit modes (reuses same input for editing); handles Enter and Add/Save actions.
+  - `ToDoTaskList.vue`: renders two sections with headings — "Pending" and "Completed" — uses `task.id` as key and exposes an Edit action that loads task into form.
+
+Data Model
+----------
+- SQLite table `todos`:
+  - `id INTEGER PRIMARY KEY AUTOINCREMENT`
+  - `text TEXT NOT NULL`
+  - `done INTEGER NOT NULL DEFAULT 0` (0/1)
+  - `created_at DATETIME DEFAULT CURRENT_TIMESTAMP` (optional)
+
+Files To Create / Modify
+-------------------------
+Create (server):
+- `server/db/todos.ts`
+- `server/api/todos.get.ts`
+- `server/api/todos.post.ts`
+- `server/api/todos/[id].put.ts`
+- (optional) `server/api/todos/[id].delete.ts`
+
+Modify (client):
+- `layers/to-do/utils/store.ts` — convert to composable + server sync
+- `layers/to-do/components/ToDoTaskForm.vue` — full-width input + edit mode
+- `layers/to-do/components/ToDoTaskList.vue` — split sections + edit action
+- `layers/to-do/pages/applications/to-do/index.vue` — minor layout adjustments so the input spans full width
+
+Implementation Steps
+--------------------
+1. Implement server DB helper and API routes; ensure DB file is created under `server/data/` at runtime.
+2. Replace class-based store with `useTaskStore()` composable that calls server APIs.
+3. Update `ToDoTaskForm.vue` to support create/edit modes and adjust styles to be full-width.
+4. Update `ToDoTaskList.vue` to display "Pending" and "Completed" sections with headings and an Edit button per item.
+5. Wire edit flow: clicking Edit populates the form, submitting performs PUT, and store updates.
+6. Manual verification: start dev server and exercise create/edit/toggle flows; refresh to confirm persistence.
+7. Add unit tests for the store (mock server calls) and run `npm run test:unit`.
+
+Verification / Manual QA
+-----------------------
+- Commands:
+  - `npm run dev` — run app
+  - Create a task, refresh page, verify it persists
+  - Edit a task, refresh page, verify change persisted
+  - Toggle completed state, verify it moves between sections
+
+Notes & Safety
+--------------
+- `server/data/todos.sqlite` should be created at runtime and ignored by git; do not commit DB file.
+- `better-sqlite3` is referenced in the project's lockfile; ensure runtime environment supports it.
+- Keep error handling simple: surface failures to the UI and allow retry.
+
+Deliverable
+-----------
+- This plan file is intended for delegation to a background agent. When executed it will create the server routes and client changes described above and include unit tests for the store.

--- a/docs/plans/2026-03-16-to-do-plan.md
+++ b/docs/plans/2026-03-16-to-do-plan.md
@@ -29,8 +29,7 @@ Data Model (Supabase / Postgres)
 Provide this SQL when provisioning the database (you said you'll create it). Suggested schema for a public to-do list (no credentials):
 
 ```sql
--- Postgres / Supabase schema for the `todos` table (public list, no credentials)
-CREATE TABLE todos (
+CREATE TABLE productivity.todos (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   text text NOT NULL,
   done boolean NOT NULL DEFAULT false,
@@ -39,7 +38,7 @@ CREATE TABLE todos (
 );
 
 -- Optional: trigger to set updated_at on row updates
-CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+CREATE OR REPLACE FUNCTION productivity.trigger_set_timestamp()
 RETURNS TRIGGER AS $$
 BEGIN
   NEW.updated_at = now();
@@ -48,9 +47,9 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER set_timestamp
-BEFORE UPDATE ON todos
+BEFORE UPDATE ON productivity.todos
 FOR EACH ROW
-EXECUTE PROCEDURE trigger_set_timestamp();
+EXECUTE PROCEDURE productivity.trigger_set_timestamp();
 ```
 
 Notes: this table is for a public to-do list (no credential_id). If you later add multi-user support, add a `credential_id` column.

--- a/docs/plans/2026-03-16-to-do-plan.md
+++ b/docs/plans/2026-03-16-to-do-plan.md
@@ -4,38 +4,62 @@ Date: 2026-03-16
 
 Goal
 ----
-- Implement server-persisted TODOs using SQLite; provide a full-width input that supports creating and editing tasks; show Pending (top) and Completed (below) sections with headings.
+- Implement server-persisted TODOs using Supabase (Postgres) via the existing Supabase client helper; provide a full-width input that supports creating and editing tasks; show Pending (top) and Completed (below) sections with headings.
 
 Chosen Approach
 ---------------
-- Use SQLite via `better-sqlite3` on the server (`server/` routes) for durable storage and simple SQL CRUD.
+- Use Supabase (Postgres) through the project's Supabase client helper (see `layers/pomodoro/server/services/storage.ts` for an example). Server routes will call a small storage service that uses the Supabase client to perform CRUD operations.
 
 High-level Architecture
 -----------------------
 - Server
-  - `server/db/todos.ts`: DB helper opening `server/data/todos.sqlite`, ensuring table exists, and exposing CRUD functions.
+  - `layers/to-do/server/services/storage.ts`: Supabase-backed storage helper that mirrors the pattern in `layers/pomodoro/server/services/storage.ts`. It should expose `load(credentialsId?)`, `save(todo, credentialsId?)`, `update(todo, credentialsId?)`, and `remove(id, credentialsId?)` functions.
   - API routes under `server/api/todos*`:
-    - `todos.get.ts` — GET all todos
+    - `todos.get.ts` — GET all todos (optionally filtered by credential/user)
     - `todos.post.ts` — POST create todo
     - `todos/[id].put.ts` — PUT update todo
     - (optional) `todos/[id].delete.ts` — DELETE todo
 - Client
-  - `layers/to-do/utils/store.ts`: composable `useTaskStore()` that holds reactive `items` and methods `load()`, `add()`, `update()`, `toggleDone()`, `setEditing()`, `saveEditing()` and syncs with server via `$fetch`.
-  - `ToDoTaskForm.vue`: full-width input, supports create and edit modes (reuses same input for editing); handles Enter and Add/Save actions.
-  - `ToDoTaskList.vue`: renders two sections with headings — "Pending" and "Completed" — uses `task.id` as key and exposes an Edit action that loads task into form.
+  - `layers/to-do/utils/store.ts`: composable `useTaskStore()` that holds reactive `items` and methods `load()`, `add()`, `update()`, `toggleDone()`, `setEditing()`, `saveEditing()` and syncs with server via `$fetch` calling the above API routes.
+  - `ToDoTaskForm.vue`: full-width input, supports create and edit modes (reuses same input for editing); handles Enter and Add/Save actions and shows loading/disabled state during requests.
+  - `ToDoTaskList.vue`: renders two sections with headings — "Pending" and "Completed" — uses `task.id` as key and exposes an Edit action that loads a task into the form.
 
-Data Model
-----------
-- SQLite table `todos`:
-  - `id INTEGER PRIMARY KEY AUTOINCREMENT`
-  - `text TEXT NOT NULL`
-  - `done INTEGER NOT NULL DEFAULT 0` (0/1)
-  - `created_at DATETIME DEFAULT CURRENT_TIMESTAMP` (optional)
+Data Model (Supabase / Postgres)
+--------------------------------
+Provide this SQL when provisioning the database (you said you'll create it). Suggested schema:
+
+```sql
+-- Postgres / Supabase schema for the `todos` table
+CREATE TABLE todos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  credential_id uuid NOT NULL,
+  text text NOT NULL,
+  done boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Optional: trigger to set updated_at on row updates
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON todos
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
+```
+
+Notes: use `credential_id` to scope tasks to a user or credential; adjust nullability if you want anonymous lists.
 
 Files To Create / Modify
 -------------------------
 Create (server):
-- `server/db/todos.ts`
+- `layers/to-do/server/services/storage.ts` — Supabase-backed storage helper (patterned after `layers/pomodoro/server/services/storage.ts`).
 - `server/api/todos.get.ts`
 - `server/api/todos.post.ts`
 - `server/api/todos/[id].put.ts`
@@ -49,28 +73,28 @@ Modify (client):
 
 Implementation Steps
 --------------------
-1. Implement server DB helper and API routes; ensure DB file is created under `server/data/` at runtime.
-2. Replace class-based store with `useTaskStore()` composable that calls server APIs.
-3. Update `ToDoTaskForm.vue` to support create/edit modes and adjust styles to be full-width.
-4. Update `ToDoTaskList.vue` to display "Pending" and "Completed" sections with headings and an Edit button per item.
-5. Wire edit flow: clicking Edit populates the form, submitting performs PUT, and store updates.
-6. Manual verification: start dev server and exercise create/edit/toggle flows; refresh to confirm persistence.
-7. Add unit tests for the store (mock server calls) and run `npm run test:unit`.
+1. Implement Supabase-backed storage helper in `layers/to-do/server/services/storage.ts` using the existing helper pattern (call `useProductivitySupabaseClient()` or a `useToDoSupabaseClient()` wrapper).
+2. Implement server API routes that call the storage helper: `GET /api/todos`, `POST /api/todos`, `PUT /api/todos/:id`, and optional `DELETE /api/todos/:id`.
+3. Replace the class-based store with `useTaskStore()` composable that calls the API routes and keeps `items` reactive.
+4. Update `ToDoTaskForm.vue` to support create/edit modes and adjust styles to be full-width; wire submit to call the store's `add` or `saveEditing`.
+5. Update `ToDoTaskList.vue` to display "Pending" and "Completed" sections with headings, use `task.id` as `:key`, and add an Edit action that populates the form.
+6. Wire edit flow: clicking Edit populates the form, submitting performs a PUT to the API, and the store updates locally on success.
+7. Add unit tests for the store (mock fetch/Supabase) and run `npm run test:unit`.
 
 Verification / Manual QA
 -----------------------
 - Commands:
   - `npm run dev` — run app
-  - Create a task, refresh page, verify it persists
+  - Create a task, refresh page, verify it persists in Supabase
   - Edit a task, refresh page, verify change persisted
   - Toggle completed state, verify it moves between sections
 
 Notes & Safety
 --------------
-- `server/data/todos.sqlite` should be created at runtime and ignored by git; do not commit DB file.
-- `better-sqlite3` is referenced in the project's lockfile; ensure runtime environment supports it.
+- Do not commit Supabase credentials or environment variables. Use the existing environment/config pattern and the project's Supabase client helper.
+- Reuse the existing Supabase client helper (for example `useProductivitySupabaseClient()` in `layers/productivity/server/services/database.ts`) rather than creating new clients to avoid duplicate connections.
 - Keep error handling simple: surface failures to the UI and allow retry.
 
 Deliverable
 -----------
-- This plan file is intended for delegation to a background agent. When executed it will create the server routes and client changes described above and include unit tests for the store.
+- This plan file is intended for delegation to a background agent. When executed it will create the Supabase-backed storage helper, server API routes, client composable, and UI changes described above and include unit tests for the store.

--- a/layers/base/components/icons/static/WlEditIcon.vue
+++ b/layers/base/components/icons/static/WlEditIcon.vue
@@ -1,0 +1,19 @@
+<template>
+  <WlIcon :size="props.size">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
+      <path d="M20.71 7.04a1.003 1.003 0 0 0 0-1.42l-2.34-2.34a1.003 1.003 0 0 0-1.42 0l-1.83 1.83 3.75 3.75 1.84-1.82z" />
+    </svg>
+  </WlIcon>
+</template>
+
+<script lang="ts" setup>
+import type { WlIconSize } from '~~/layers/base/components/icons/WlIcon.vue';
+import WlIcon from '~~/layers/base/components/icons/WlIcon.vue';
+
+type Props = {
+  size?: WlIconSize
+};
+
+const props = defineProps<Props>();
+</script>

--- a/layers/to-do/components/ToDoTaskForm.vue
+++ b/layers/to-do/components/ToDoTaskForm.vue
@@ -37,7 +37,7 @@ import WlButton from '~~/layers/experiments/components/forms-input/buttons/WlBut
 import WlInput from '~~/layers/experiments/components/forms-input/input/WlInput.vue';
 
 const props = defineProps<{
-  store: ReturnType<typeof import('~~/layers/to-do/utils/store').useTaskStore>;
+  store: ReturnType<typeof import('~~/layers/to-do/utils/store').useTaskStore>
 }>();
 
 const taskText = ref('');

--- a/layers/to-do/components/ToDoTaskForm.vue
+++ b/layers/to-do/components/ToDoTaskForm.vue
@@ -1,36 +1,75 @@
 <template>
-  <div class="flex items-center gap-2">
-    <label for="new-task" class="sr-only">New task:</label>
+  <div class="flex w-full items-center gap-2">
+    <label for="new-task" class="sr-only">{{ isEditing ? 'Edit task' : 'New task' }}:</label>
     <WlInput
       id="new-task"
-      v-model="newTask"
+      v-model="taskText"
       type="text"
-      placeholder="New task..."
-      @keydown.enter="onAddTask"
+      class="flex-1"
+      :placeholder="isEditing ? 'Edit task...' : 'New task...'"
+      :disabled="store.loading.value"
+      @keydown.enter="onSubmit"
+      @keydown.esc="onCancel"
     />
-    <WlButton variant="primary" @click="onAddTask">
-      Add
+    <WlButton
+      v-if="isEditing"
+      variant="secondary"
+      :disabled="store.loading.value"
+      @click="onCancel"
+    >
+      Cancel
+    </WlButton>
+    <WlButton
+      variant="primary"
+      :disabled="store.loading.value || taskText.trim() === ''"
+      @click="onSubmit"
+    >
+      {{ isEditing ? 'Save' : 'Add' }}
     </WlButton>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import WlButton from '~~/layers/experiments/components/forms-input/buttons/WlButton.vue';
 import WlInput from '~~/layers/experiments/components/forms-input/input/WlInput.vue';
-import { injectTaskStore } from '~~/layers/to-do/utils/store';
 
-const taskStore = injectTaskStore();
+const props = defineProps<{
+  store: ReturnType<typeof import('~~/layers/to-do/utils/store').useTaskStore>;
+}>();
 
-const newTask = ref('');
+const taskText = ref('');
 
-function onAddTask() {
-  if (newTask.value.trim() === '') {
+const isEditing = computed(() => props.store.editingTask.value !== null);
+
+// Watch for editing mode changes
+watch(() => props.store.editingTask.value, (editingTask) => {
+  if (editingTask) {
+    taskText.value = editingTask.text;
+  }
+  else {
+    taskText.value = '';
+  }
+});
+
+async function onSubmit() {
+  if (taskText.value.trim() === '') {
     return;
   }
 
-  taskStore.add(newTask.value);
-  newTask.value = '';
+  if (isEditing.value) {
+    await props.store.saveEditing(taskText.value);
+  }
+  else {
+    await props.store.add(taskText.value);
+  }
+
+  taskText.value = '';
+}
+
+function onCancel() {
+  props.store.cancelEditing();
+  taskText.value = '';
 }
 </script>

--- a/layers/to-do/components/ToDoTaskForm.vue
+++ b/layers/to-do/components/ToDoTaskForm.vue
@@ -6,6 +6,7 @@
       v-model="taskText"
       type="text"
       class="flex-1"
+      autocomplete="off"
       :placeholder="isEditing ? 'Edit task...' : 'New task...'"
       :disabled="store.loading.value"
       @keydown.enter="onSubmit"

--- a/layers/to-do/components/ToDoTaskList.vue
+++ b/layers/to-do/components/ToDoTaskList.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="space-y-4">
+  <div class="space-y-4 md:grid md:grid-cols-2 md:gap-6 md:space-y-0">
     <div v-if="pendingTasks.length > 0">
       <h3 class="mb-2 text-lg font-semibold">
         Pending
       </h3>
       <ul class="space-y-1">
-        <li v-for="task in pendingTasks" :key="task.id">
-          <label :for="`input-${task.id}`" class="flex items-center gap-2 py-1">
+        <li v-for="task in pendingTasks" :key="task.id" class="-mx-2 rounded px-2 hover:bg-slate-50 dark:hover:bg-slate-700">
+          <label :for="`input-${task.id}`" class="flex cursor-pointer items-center gap-2 py-1">
             <input
               :id="`input-${task.id}`"
               type="checkbox"
@@ -15,24 +15,30 @@
               @change="store.toggleDone(task.id)"
             >
             <span class="flex-1">{{ task.text }}</span>
-            <WlIconButton
-              :disabled="store.loading.value"
-              :variant="'secondary'"
-              title="Edit"
-              aria-label="Edit task"
-              @click.stop="store.setEditing(task)"
-            >
-              <WlEditIcon />
-            </WlIconButton>
-            <WlIconButton
-              :disabled="store.loading.value"
-              :variant="'danger'"
-              title="Delete"
-              aria-label="Delete task"
-              @click.stop="store.remove(task.id)"
-            >
-              <WlTrashAnimatedIcon :progress="0" />
-            </WlIconButton>
+            <div class="flex items-center gap-1">
+              <a
+                href="#"
+                role="button"
+                title="Edit"
+                aria-label="Edit task"
+                :class="{ 'pointer-events-none opacity-50': store.loading.value }"
+                class="flex size-8 items-center justify-center rounded"
+                @click.stop.prevent="store.setEditing(task)"
+              >
+                <WlEditIcon />
+              </a>
+              <a
+                href="#"
+                role="button"
+                title="Delete"
+                aria-label="Delete task"
+                :class="{ 'pointer-events-none text-danger-700 opacity-50': store.loading.value, 'text-danger-700': !store.loading.value }"
+                class="flex size-8 items-center justify-center rounded"
+                @click.stop.prevent="store.remove(task.id)"
+              >
+                <WlTrashAnimatedIcon :progress="0" />
+              </a>
+            </div>
           </label>
         </li>
       </ul>
@@ -44,7 +50,7 @@
       </h3>
       <ul class="space-y-1">
         <li v-for="task in completedTasks" :key="task.id">
-          <label :for="`input-${task.id}`" class="flex items-center gap-2 py-1">
+          <label :for="`input-${task.id}`" class="flex cursor-pointer items-center gap-2 rounded py-1 hover:bg-slate-50 dark:hover:bg-slate-800">
             <input
               :id="`input-${task.id}`"
               type="checkbox"
@@ -53,24 +59,28 @@
               @change="store.toggleDone(task.id)"
             >
             <span class="flex-1 line-through opacity-60">{{ task.text }}</span>
-            <WlIconButton
-              :disabled="store.loading.value"
-              :variant="'secondary'"
+            <a
+              href="#"
+              role="button"
               title="Edit"
               aria-label="Edit task"
-              @click.stop="store.setEditing(task)"
+              :class="{ 'pointer-events-none opacity-50': store.loading.value }"
+              class="rounded p-1"
+              @click.stop.prevent="store.setEditing(task)"
             >
               <WlEditIcon />
-            </WlIconButton>
-            <WlIconButton
-              :disabled="store.loading.value"
-              :variant="'danger'"
+            </a>
+            <a
+              href="#"
+              role="button"
               title="Delete"
               aria-label="Delete task"
-              @click.stop="store.remove(task.id)"
+              :class="{ 'pointer-events-none text-danger-700 opacity-50': store.loading.value, 'text-danger-700': !store.loading.value }"
+              class="rounded p-1"
+              @click.stop.prevent="store.remove(task.id)"
             >
               <WlTrashAnimatedIcon :progress="0" />
-            </WlIconButton>
+            </a>
           </label>
         </li>
       </ul>
@@ -87,7 +97,6 @@ import { computed } from 'vue';
 
 import WlTrashAnimatedIcon from '~~/layers/base/components/icons/animated/WlTrashAnimatedIcon.vue';
 import WlEditIcon from '~~/layers/base/components/icons/static/WlEditIcon.vue';
-import WlIconButton from '~~/layers/experiments/components/forms-input/buttons/WlIconButton.vue';
 import type { Task, useTaskStore } from '~~/layers/to-do/utils/store';
 
 const props = defineProps<{

--- a/layers/to-do/components/ToDoTaskList.vue
+++ b/layers/to-do/components/ToDoTaskList.vue
@@ -15,20 +15,24 @@
               @change="store.toggleDone(task.id)"
             >
             <span class="flex-1">{{ task.text }}</span>
-            <WlButton
-              variant="secondary"
+            <WlIconButton
               :disabled="store.loading.value"
-              @click="store.setEditing(task)"
+              :variant="'secondary'"
+              title="Edit"
+              aria-label="Edit task"
+              @click.stop="store.setEditing(task)"
             >
-              Edit
-            </WlButton>
-            <WlButton
-              variant="danger"
+              <WlEditIcon />
+            </WlIconButton>
+            <WlIconButton
               :disabled="store.loading.value"
-              @click="store.remove(task.id)"
+              :variant="'danger'"
+              title="Delete"
+              aria-label="Delete task"
+              @click.stop="store.remove(task.id)"
             >
-              Delete
-            </WlButton>
+              <WlTrashAnimatedIcon :progress="0" />
+            </WlIconButton>
           </label>
         </li>
       </ul>
@@ -49,26 +53,30 @@
               @change="store.toggleDone(task.id)"
             >
             <span class="flex-1 line-through opacity-60">{{ task.text }}</span>
-            <WlButton
-              variant="secondary"
+            <WlIconButton
               :disabled="store.loading.value"
-              @click="store.setEditing(task)"
+              :variant="'secondary'"
+              title="Edit"
+              aria-label="Edit task"
+              @click.stop="store.setEditing(task)"
             >
-              Edit
-            </WlButton>
-            <WlButton
-              variant="danger"
+              <WlEditIcon />
+            </WlIconButton>
+            <WlIconButton
               :disabled="store.loading.value"
-              @click="store.remove(task.id)"
+              :variant="'danger'"
+              title="Delete"
+              aria-label="Delete task"
+              @click.stop="store.remove(task.id)"
             >
-              Delete
-            </WlButton>
+              <WlTrashAnimatedIcon :progress="0" />
+            </WlIconButton>
           </label>
         </li>
       </ul>
     </div>
 
-    <div v-if="pendingTasks.length === 0 && completedTasks.length === 0" class="text-center text-gray-500 py-8">
+    <div v-if="pendingTasks.length === 0 && completedTasks.length === 0" class="py-8 text-center text-gray-500">
       No tasks yet. Add one above!
     </div>
   </div>
@@ -77,11 +85,13 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
 
-import WlButton from '~~/layers/experiments/components/forms-input/buttons/WlButton.vue';
+import WlTrashAnimatedIcon from '~~/layers/base/components/icons/animated/WlTrashAnimatedIcon.vue';
+import WlEditIcon from '~~/layers/base/components/icons/static/WlEditIcon.vue';
+import WlIconButton from '~~/layers/experiments/components/forms-input/buttons/WlIconButton.vue';
 import type { Task } from '~~/layers/to-do/utils/store';
 
 const props = defineProps<{
-  store: ReturnType<typeof import('~~/layers/to-do/utils/store').useTaskStore>;
+  store: ReturnType<typeof import('~~/layers/to-do/utils/store').useTaskStore>
 }>();
 
 const pendingTasks = computed(() => props.store.items.value.filter((task: Task) => !task.done));

--- a/layers/to-do/components/ToDoTaskList.vue
+++ b/layers/to-do/components/ToDoTaskList.vue
@@ -88,10 +88,10 @@ import { computed } from 'vue';
 import WlTrashAnimatedIcon from '~~/layers/base/components/icons/animated/WlTrashAnimatedIcon.vue';
 import WlEditIcon from '~~/layers/base/components/icons/static/WlEditIcon.vue';
 import WlIconButton from '~~/layers/experiments/components/forms-input/buttons/WlIconButton.vue';
-import type { Task } from '~~/layers/to-do/utils/store';
+import type { Task, useTaskStore } from '~~/layers/to-do/utils/store';
 
 const props = defineProps<{
-  store: ReturnType<typeof import('~~/layers/to-do/utils/store').useTaskStore>
+  store: ReturnType<typeof useTaskStore>
 }>();
 
 const pendingTasks = computed(() => props.store.items.value.filter((task: Task) => !task.done));

--- a/layers/to-do/components/ToDoTaskList.vue
+++ b/layers/to-do/components/ToDoTaskList.vue
@@ -4,86 +4,21 @@
       <h3 class="mb-2 text-lg font-semibold">
         Pending
       </h3>
-      <ul class="space-y-1">
-        <li v-for="task in pendingTasks" :key="task.id" class="-mx-2 rounded px-2 hover:bg-slate-50 dark:hover:bg-slate-700">
-          <label :for="`input-${task.id}`" class="flex cursor-pointer items-center gap-2 py-1">
-            <input
-              :id="`input-${task.id}`"
-              type="checkbox"
-              :checked="task.done"
-              :disabled="store.loading.value"
-              @change="store.toggleDone(task.id)"
-            >
-            <span class="flex-1">{{ task.text }}</span>
-            <div class="flex items-center gap-1">
-              <a
-                href="#"
-                role="button"
-                title="Edit"
-                aria-label="Edit task"
-                :class="{ 'pointer-events-none opacity-50': store.loading.value }"
-                class="flex size-8 items-center justify-center rounded"
-                @click.stop.prevent="store.setEditing(task)"
-              >
-                <WlEditIcon />
-              </a>
-              <a
-                href="#"
-                role="button"
-                title="Delete"
-                aria-label="Delete task"
-                :class="{ 'pointer-events-none text-danger-700 opacity-50': store.loading.value, 'text-danger-700': !store.loading.value }"
-                class="flex size-8 items-center justify-center rounded"
-                @click.stop.prevent="store.remove(task.id)"
-              >
-                <WlTrashAnimatedIcon :progress="0" />
-              </a>
-            </div>
-          </label>
-        </li>
-      </ul>
+      <ToDoTaskListItems
+        :tasks="pendingTasks"
+        :store="props.store"
+      />
     </div>
 
     <div v-if="completedTasks.length > 0">
       <h3 class="mb-2 text-lg font-semibold">
         Completed
       </h3>
-      <ul class="space-y-1">
-        <li v-for="task in completedTasks" :key="task.id">
-          <label :for="`input-${task.id}`" class="flex cursor-pointer items-center gap-2 rounded py-1 hover:bg-slate-50 dark:hover:bg-slate-800">
-            <input
-              :id="`input-${task.id}`"
-              type="checkbox"
-              :checked="task.done"
-              :disabled="store.loading.value"
-              @change="store.toggleDone(task.id)"
-            >
-            <span class="flex-1 line-through opacity-60">{{ task.text }}</span>
-            <a
-              href="#"
-              role="button"
-              title="Edit"
-              aria-label="Edit task"
-              :class="{ 'pointer-events-none opacity-50': store.loading.value }"
-              class="rounded p-1"
-              @click.stop.prevent="store.setEditing(task)"
-            >
-              <WlEditIcon />
-            </a>
-            <a
-              href="#"
-              role="button"
-              title="Delete"
-              aria-label="Delete task"
-              :class="{ 'pointer-events-none text-danger-700 opacity-50': store.loading.value, 'text-danger-700': !store.loading.value }"
-              class="rounded p-1"
-              @click.stop.prevent="store.remove(task.id)"
-            >
-              <WlTrashAnimatedIcon :progress="0" />
-            </a>
-          </label>
-        </li>
-      </ul>
+      <ToDoTaskListItems
+        :tasks="completedTasks"
+        :store="props.store"
+        :completed="true"
+      />
     </div>
 
     <div v-if="pendingTasks.length === 0 && completedTasks.length === 0" class="py-8 text-center text-gray-500">
@@ -95,9 +30,9 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
 
-import WlTrashAnimatedIcon from '~~/layers/base/components/icons/animated/WlTrashAnimatedIcon.vue';
-import WlEditIcon from '~~/layers/base/components/icons/static/WlEditIcon.vue';
 import type { Task, useTaskStore } from '~~/layers/to-do/utils/store';
+
+import ToDoTaskListItems from './ToDoTaskListItems.vue';
 
 const props = defineProps<{
   store: ReturnType<typeof useTaskStore>

--- a/layers/to-do/components/ToDoTaskList.vue
+++ b/layers/to-do/components/ToDoTaskList.vue
@@ -1,21 +1,89 @@
 <template>
-  <ul>
-    <li v-for="(task, index) in taskStore.items" :key="task.text">
-      <label :for="`input-${index}`" class="flex gap-2 py-1">
-        <input
-          :id="`input-${index}`"
-          type="checkbox"
-          :checked="task.done"
-          @change="task.done = !task.done"
-        >
-        <span>{{ task.text }}</span>
-      </label>
-    </li>
-  </ul>
+  <div class="space-y-4">
+    <div v-if="pendingTasks.length > 0">
+      <h3 class="mb-2 text-lg font-semibold">
+        Pending
+      </h3>
+      <ul class="space-y-1">
+        <li v-for="task in pendingTasks" :key="task.id">
+          <label :for="`input-${task.id}`" class="flex items-center gap-2 py-1">
+            <input
+              :id="`input-${task.id}`"
+              type="checkbox"
+              :checked="task.done"
+              :disabled="store.loading.value"
+              @change="store.toggleDone(task.id)"
+            >
+            <span class="flex-1">{{ task.text }}</span>
+            <WlButton
+              variant="secondary"
+              :disabled="store.loading.value"
+              @click="store.setEditing(task)"
+            >
+              Edit
+            </WlButton>
+            <WlButton
+              variant="danger"
+              :disabled="store.loading.value"
+              @click="store.remove(task.id)"
+            >
+              Delete
+            </WlButton>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <div v-if="completedTasks.length > 0">
+      <h3 class="mb-2 text-lg font-semibold">
+        Completed
+      </h3>
+      <ul class="space-y-1">
+        <li v-for="task in completedTasks" :key="task.id">
+          <label :for="`input-${task.id}`" class="flex items-center gap-2 py-1">
+            <input
+              :id="`input-${task.id}`"
+              type="checkbox"
+              :checked="task.done"
+              :disabled="store.loading.value"
+              @change="store.toggleDone(task.id)"
+            >
+            <span class="flex-1 line-through opacity-60">{{ task.text }}</span>
+            <WlButton
+              variant="secondary"
+              :disabled="store.loading.value"
+              @click="store.setEditing(task)"
+            >
+              Edit
+            </WlButton>
+            <WlButton
+              variant="danger"
+              :disabled="store.loading.value"
+              @click="store.remove(task.id)"
+            >
+              Delete
+            </WlButton>
+          </label>
+        </li>
+      </ul>
+    </div>
+
+    <div v-if="pendingTasks.length === 0 && completedTasks.length === 0" class="text-center text-gray-500 py-8">
+      No tasks yet. Add one above!
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { injectTaskStore } from '~~/layers/to-do/utils/store';
+import { computed } from 'vue';
 
-const taskStore = injectTaskStore();
+import WlButton from '~~/layers/experiments/components/forms-input/buttons/WlButton.vue';
+import type { Task } from '~~/layers/to-do/utils/store';
+
+const props = defineProps<{
+  store: ReturnType<typeof import('~~/layers/to-do/utils/store').useTaskStore>;
+}>();
+
+const pendingTasks = computed(() => props.store.items.value.filter((task: Task) => !task.done));
+const completedTasks = computed(() => props.store.items.value.filter((task: Task) => task.done));
 </script>

--- a/layers/to-do/components/ToDoTaskListItems.vue
+++ b/layers/to-do/components/ToDoTaskListItems.vue
@@ -1,0 +1,80 @@
+<template>
+  <ul class="space-y-1">
+    <li v-for="task in tasksList" :key="task.id" :class="itemClass">
+      <label :for="`input-${task.id}`" class="flex cursor-pointer items-center gap-2 py-1">
+        <input
+          :id="`input-${task.id}`"
+          type="checkbox"
+          :checked="task.done"
+          :disabled="loading"
+          @change="toggleDone(task.id)"
+        >
+        <span :class="completedFlag ? 'flex-1 line-through opacity-60' : 'flex-1'">{{ task.text }}</span>
+        <div class="flex items-center gap-1">
+          <a
+            href="#"
+            role="button"
+            title="Edit"
+            aria-label="Edit task"
+            :class="{ 'pointer-events-none opacity-50': loading }"
+            class="flex size-8 items-center justify-center rounded"
+            @click.stop.prevent="setEditing(task)"
+          >
+            <WlEditIcon />
+          </a>
+          <a
+            href="#"
+            role="button"
+            title="Delete"
+            aria-label="Delete task"
+            :class="{ 'pointer-events-none text-danger-700 opacity-50': loading, 'text-danger-700': !loading }"
+            class="flex size-8 items-center justify-center rounded"
+            @click.stop.prevent="removeTask(task.id)"
+          >
+            <WlTrashAnimatedIcon :progress="0" />
+          </a>
+        </div>
+      </label>
+    </li>
+  </ul>
+</template>
+
+<script lang="ts" setup>
+import { computed, toRef } from 'vue';
+
+import WlTrashAnimatedIcon from '~~/layers/base/components/icons/animated/WlTrashAnimatedIcon.vue';
+import WlEditIcon from '~~/layers/base/components/icons/static/WlEditIcon.vue';
+import type { Task, useTaskStore } from '~~/layers/to-do/utils/store';
+
+const props = defineProps<{
+  tasks: Task[]
+  store: ReturnType<typeof useTaskStore>
+  completed?: boolean
+  itemClass?: string
+}>();
+
+// Preserve reactivity when parent passes refs/computeds
+const tasksRef = toRef(props, 'tasks');
+const storeRef = toRef(props, 'store');
+const completedRef = toRef(props, 'completed');
+const itemClass = computed(() => props.itemClass ?? '-mx-2 rounded px-2 hover:bg-slate-50 dark:hover:bg-slate-700');
+
+// Expose local names used in template for clarity and helpers that call through to the passed store
+const tasksList = computed(() => tasksRef.value ?? []);
+const storeObj = computed(() => storeRef.value);
+const completedFlag = computed(() => !!completedRef.value);
+const loading = computed(() => !!storeObj.value?.loading?.value);
+
+function toggleDone(id: string) {
+  // call through to the passed store; the store will update its items and the parent lists are computed
+  storeObj.value.toggleDone(id);
+}
+
+function setEditing(task: Task) {
+  storeObj.value.setEditing(task);
+}
+
+function removeTask(id: string) {
+  storeObj.value.remove(id);
+}
+</script>

--- a/layers/to-do/pages/applications/to-do/index.vue
+++ b/layers/to-do/pages/applications/to-do/index.vue
@@ -13,8 +13,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted } from 'vue';
-
+import { useAsyncData } from '#app';
 import WlContainer from '~~/layers/base/components/layout/WlContainer.vue';
 import ToDoTaskForm from '~~/layers/to-do/components/ToDoTaskForm.vue';
 import ToDoTaskList from '~~/layers/to-do/components/ToDoTaskList.vue';
@@ -22,7 +21,17 @@ import { useTaskStore } from '~~/layers/to-do/utils/store';
 
 const taskStore = useTaskStore();
 
-onMounted(async () => {
-  await taskStore.load();
+// Fetch tasks on the server when possible so the page is rendered with items
+// already populated on first load. Return the fetched todos so Nuxt serializes
+// them to the client and we can populate the client-side store with the
+// identical array to avoid hydration mismatches.
+const { data: serverTodos } = await useAsyncData('todos', async () => {
+  const todos = await $fetch('/api/todos');
+  return todos;
 });
+
+// Ensure the reactive store has the same items used for server rendering.
+if (serverTodos && serverTodos.value) {
+  taskStore.items.value = serverTodos.value;
+}
 </script>

--- a/layers/to-do/pages/applications/to-do/index.vue
+++ b/layers/to-do/pages/applications/to-do/index.vue
@@ -21,17 +21,7 @@ import { useTaskStore } from '~~/layers/to-do/utils/store';
 
 const taskStore = useTaskStore();
 
-// Fetch tasks on the server when possible so the page is rendered with items
-// already populated on first load. Return the fetched todos so Nuxt serializes
-// them to the client and we can populate the client-side store with the
-// identical array to avoid hydration mismatches.
-const { data: serverTodos } = await useAsyncData('todos', async () => {
-  const todos = await $fetch('/api/todos');
-  return todos;
-});
+const result = await useAsyncData('todos', () => $fetch('/api/todos'));
 
-// Ensure the reactive store has the same items used for server rendering.
-if (serverTodos && serverTodos.value) {
-  taskStore.items.value = serverTodos.value;
-}
+taskStore.items.value = result.data.value;
 </script>

--- a/layers/to-do/pages/applications/to-do/index.vue
+++ b/layers/to-do/pages/applications/to-do/index.vue
@@ -5,18 +5,24 @@
         To Do
       </h2>
       <div class="w-full rounded border p-3">
-        <ToDoTaskForm />
+        <ToDoTaskForm :store="taskStore" />
       </div>
-      <ToDoTaskList />
+      <ToDoTaskList :store="taskStore" />
     </WlContainer>
   </NuxtLayout>
 </template>
 
 <script lang="ts" setup>
+import { onMounted } from 'vue';
+
 import WlContainer from '~~/layers/base/components/layout/WlContainer.vue';
 import ToDoTaskForm from '~~/layers/to-do/components/ToDoTaskForm.vue';
 import ToDoTaskList from '~~/layers/to-do/components/ToDoTaskList.vue';
-import { provideTaskStore } from '~~/layers/to-do/utils/store';
+import { useTaskStore } from '~~/layers/to-do/utils/store';
 
-provideTaskStore();
+const taskStore = useTaskStore();
+
+onMounted(async () => {
+  await taskStore.load();
+});
 </script>

--- a/layers/to-do/pages/applications/to-do/index.vue
+++ b/layers/to-do/pages/applications/to-do/index.vue
@@ -4,7 +4,9 @@
       <h2 class="text-2xl">
         To Do
       </h2>
-      <ToDoTaskForm />
+      <div class="w-full rounded border p-3">
+        <ToDoTaskForm />
+      </div>
       <ToDoTaskList />
     </WlContainer>
   </NuxtLayout>

--- a/layers/to-do/server/services/storage.ts
+++ b/layers/to-do/server/services/storage.ts
@@ -1,0 +1,79 @@
+import { useProductivitySupabaseClient } from '~~/layers/productivity/server/services/database';
+
+const supabaseClient = useProductivitySupabaseClient();
+
+export interface TodoDto {
+  id: string;
+  text: string;
+  done: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export function useToDoStorage() {
+  async function load(): Promise<TodoDto[]> {
+    const result = await supabaseClient
+      .from('todos')
+      .select('*')
+      .order('done', { ascending: true })
+      .order('created_at', { ascending: true });
+
+    if (!result.data || result.data.length === 0) {
+      return [];
+    }
+
+    return result.data;
+  }
+
+  async function save(todo: { text: string }): Promise<TodoDto> {
+    // Check the current count to enforce the 100-item limit
+    const countResult = await supabaseClient
+      .from('todos')
+      .select('*', { count: 'exact', head: true });
+
+    const count = countResult.count || 0;
+
+    if (count >= 100) {
+      throw new Error('todo limit reached');
+    }
+
+    const result = await supabaseClient
+      .from('todos')
+      .insert({ text: todo.text, done: false })
+      .select();
+
+    if (!result.data || result.data.length === 0) {
+      throw new Error('failed to create todo');
+    }
+
+    return result.data[0];
+  }
+
+  async function update(id: string, todo: Partial<{ text: string; done: boolean }>): Promise<TodoDto> {
+    const result = await supabaseClient
+      .from('todos')
+      .update(todo)
+      .eq('id', id)
+      .select();
+
+    if (!result.data || result.data.length === 0) {
+      throw new Error('todo not found');
+    }
+
+    return result.data[0];
+  }
+
+  async function remove(id: string): Promise<void> {
+    await supabaseClient
+      .from('todos')
+      .delete()
+      .eq('id', id);
+  }
+
+  return {
+    load,
+    save,
+    update,
+    remove,
+  };
+}

--- a/layers/to-do/server/services/storage.ts
+++ b/layers/to-do/server/services/storage.ts
@@ -3,11 +3,11 @@ import { useProductivitySupabaseClient } from '~~/layers/productivity/server/ser
 const supabaseClient = useProductivitySupabaseClient();
 
 export interface TodoDto {
-  id: string;
-  text: string;
-  done: boolean;
-  created_at: string;
-  updated_at: string;
+  id: string
+  text: string
+  done: boolean
+  created_at: string
+  updated_at: string
 }
 
 export function useToDoStorage() {
@@ -49,7 +49,7 @@ export function useToDoStorage() {
     return result.data[0];
   }
 
-  async function update(id: string, todo: Partial<{ text: string; done: boolean }>): Promise<TodoDto> {
+  async function update(id: string, todo: Partial<{ text: string, done: boolean }>): Promise<TodoDto> {
     const result = await supabaseClient
       .from('todos')
       .update(todo)

--- a/layers/to-do/tests/unit/store.spec.ts
+++ b/layers/to-do/tests/unit/store.spec.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { Task } from '~~/layers/to-do/utils/store';
+import { useTaskStore } from '~~/layers/to-do/utils/store';
+
+// Mock $fetch
+const mockFetch = vi.fn();
+global.$fetch = mockFetch as typeof $fetch;
+
+describe('useTaskStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('initializes with empty items', () => {
+    const store = useTaskStore();
+
+    expect(store.items.value).toHaveLength(0);
+    expect(store.loading.value).toBe(false);
+    expect(store.editingTask.value).toBeNull();
+  });
+
+  test('loads tasks from server', async () => {
+    const mockTasks: Task[] = [
+      {
+        id: '1',
+        text: 'Task 1',
+        done: false,
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:00Z',
+      },
+      {
+        id: '2',
+        text: 'Task 2',
+        done: true,
+        created_at: '2026-03-16T01:00:00Z',
+        updated_at: '2026-03-16T01:00:00Z',
+      },
+    ];
+
+    mockFetch.mockResolvedValueOnce(mockTasks);
+
+    const store = useTaskStore();
+    await store.load();
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/todos');
+    expect(store.items.value).toEqual(mockTasks);
+  });
+
+  test('adds a new task', async () => {
+    const newTask: Task = {
+      id: '3',
+      text: 'New Task',
+      done: false,
+      created_at: '2026-03-16T02:00:00Z',
+      updated_at: '2026-03-16T02:00:00Z',
+    };
+
+    mockFetch.mockResolvedValueOnce(newTask);
+
+    const store = useTaskStore();
+    await store.add('New Task');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/todos', {
+      method: 'POST',
+      body: { text: 'New Task' },
+    });
+    expect(store.items.value).toHaveLength(1);
+    expect(store.items.value[0]).toEqual(newTask);
+  });
+
+  test('updates a task', async () => {
+    const existingTask: Task = {
+      id: '1',
+      text: 'Task 1',
+      done: false,
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    };
+
+    const updatedTask: Task = {
+      ...existingTask,
+      text: 'Updated Task',
+      updated_at: '2026-03-16T03:00:00Z',
+    };
+
+    mockFetch.mockResolvedValueOnce([existingTask]);
+    mockFetch.mockResolvedValueOnce(updatedTask);
+
+    const store = useTaskStore();
+    await store.load();
+    await store.update('1', { text: 'Updated Task' });
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/todos/1', {
+      method: 'PUT',
+      body: { text: 'Updated Task' },
+    });
+    expect(store.items.value[0].text).toBe('Updated Task');
+  });
+
+  test('toggles task done status', async () => {
+    const existingTask: Task = {
+      id: '1',
+      text: 'Task 1',
+      done: false,
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    };
+
+    const toggledTask: Task = {
+      ...existingTask,
+      done: true,
+      updated_at: '2026-03-16T04:00:00Z',
+    };
+
+    mockFetch.mockResolvedValueOnce([existingTask]);
+    mockFetch.mockResolvedValueOnce(toggledTask);
+
+    const store = useTaskStore();
+    await store.load();
+    await store.toggleDone('1');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/todos/1', {
+      method: 'PUT',
+      body: { done: true },
+    });
+    expect(store.items.value[0].done).toBe(true);
+  });
+
+  test('removes a task', async () => {
+    const existingTask: Task = {
+      id: '1',
+      text: 'Task 1',
+      done: false,
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    };
+
+    mockFetch.mockResolvedValueOnce([existingTask]);
+    mockFetch.mockResolvedValueOnce(undefined);
+
+    const store = useTaskStore();
+    await store.load();
+    await store.remove('1');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/todos/1', {
+      method: 'DELETE',
+    });
+    expect(store.items.value).toHaveLength(0);
+  });
+
+  test('sets and cancels editing', () => {
+    const task: Task = {
+      id: '1',
+      text: 'Task 1',
+      done: false,
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    };
+
+    const store = useTaskStore();
+    store.items.value = [task];
+
+    store.setEditing(task);
+    expect(store.editingTask.value).toEqual({ id: '1', text: 'Task 1' });
+
+    store.cancelEditing();
+    expect(store.editingTask.value).toBeNull();
+  });
+
+  test('saves editing', async () => {
+    const existingTask: Task = {
+      id: '1',
+      text: 'Task 1',
+      done: false,
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    };
+
+    const updatedTask: Task = {
+      ...existingTask,
+      text: 'Edited Task',
+      updated_at: '2026-03-16T05:00:00Z',
+    };
+
+    mockFetch.mockResolvedValueOnce([existingTask]);
+    mockFetch.mockResolvedValueOnce(updatedTask);
+
+    const store = useTaskStore();
+    await store.load();
+
+    store.setEditing(existingTask);
+    await store.saveEditing('Edited Task');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/todos/1', {
+      method: 'PUT',
+      body: { text: 'Edited Task' },
+    });
+    expect(store.items.value[0].text).toBe('Edited Task');
+    expect(store.editingTask.value).toBeNull();
+  });
+
+  test('sorts items with pending first', async () => {
+    const tasks: Task[] = [
+      {
+        id: '1',
+        text: 'Completed Task',
+        done: true,
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:00Z',
+      },
+      {
+        id: '2',
+        text: 'Pending Task',
+        done: false,
+        created_at: '2026-03-16T01:00:00Z',
+        updated_at: '2026-03-16T01:00:00Z',
+      },
+    ];
+
+    const newTask: Task = {
+      id: '3',
+      text: 'New Pending Task',
+      done: false,
+      created_at: '2026-03-16T02:00:00Z',
+      updated_at: '2026-03-16T02:00:00Z',
+    };
+
+    mockFetch.mockResolvedValueOnce(tasks);
+    mockFetch.mockResolvedValueOnce(newTask);
+
+    const store = useTaskStore();
+    await store.load();
+    await store.add('New Pending Task');
+
+    // Verify pending tasks come first
+    const pendingTasks = store.items.value.filter(t => !t.done);
+    const completedTasks = store.items.value.filter(t => t.done);
+
+    expect(pendingTasks).toHaveLength(2);
+    expect(completedTasks).toHaveLength(1);
+    expect(store.items.value[0].done).toBe(false);
+    expect(store.items.value[1].done).toBe(false);
+    expect(store.items.value[2].done).toBe(true);
+  });
+});

--- a/layers/to-do/utils/store.ts
+++ b/layers/to-do/utils/store.ts
@@ -1,16 +1,16 @@
 import { ref } from 'vue';
 
 export interface Task {
-  id: string;
-  text: string;
-  done: boolean;
-  created_at: string;
-  updated_at: string;
+  id: string
+  text: string
+  done: boolean
+  created_at: string
+  updated_at: string
 }
 
 export interface TaskEdit {
-  id: string;
-  text: string;
+  id: string
+  text: string
 }
 
 export function useTaskStore() {
@@ -50,7 +50,7 @@ export function useTaskStore() {
     }
   }
 
-  async function update(id: string, updates: Partial<{ text: string; done: boolean }>) {
+  async function update(id: string, updates: Partial<{ text: string, done: boolean }>) {
     loading.value = true;
     try {
       const updatedTask = await $fetch<Task>(`/api/todos/${id}`, {

--- a/layers/to-do/utils/store.ts
+++ b/layers/to-do/utils/store.ts
@@ -1,40 +1,125 @@
-import { inject, provide, reactive } from 'vue';
+import { ref } from 'vue';
 
-// TODO: Check whether this store should live in the `pages` directory.
-export class TaskStore {
-  // Try doing this without the `reactive()` call and investigate the differences.
-  items = reactive([
-    {
-      done: false,
-      text: 'Create blog website',
-    },
-    {
-      done: false,
-      text: 'Create to do app',
-    },
-    {
-      done: false,
-      text: 'Create blog article',
-    },
-    {
-      done: false,
-      text: 'Review blog article',
-    },
-  ]);
+export interface Task {
+  id: string;
+  text: string;
+  done: boolean;
+  created_at: string;
+  updated_at: string;
+}
 
-  add(task: string) {
-    this.items.push({
-      done: false,
-      text: task,
-    });
+export interface TaskEdit {
+  id: string;
+  text: string;
+}
+
+export function useTaskStore() {
+  const items = ref<Task[]>([]);
+  const loading = ref(false);
+  const editingTask = ref<TaskEdit | null>(null);
+
+  async function load() {
+    loading.value = true;
+    try {
+      const response = await $fetch<Task[]>('/api/todos');
+      items.value = response;
+    }
+    finally {
+      loading.value = false;
+    }
   }
-}
 
-export function provideTaskStore() {
-  // Optionally return the new instance if you need it in the top-level component.
-  provide('tasks', new TaskStore());
-}
+  async function add(text: string) {
+    loading.value = true;
+    try {
+      const newTask = await $fetch<Task>('/api/todos', {
+        method: 'POST',
+        body: { text },
+      });
+      items.value.push(newTask);
+      // Re-sort after adding
+      items.value.sort((a, b) => {
+        if (a.done !== b.done) {
+          return a.done ? 1 : -1;
+        }
+        return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      });
+    }
+    finally {
+      loading.value = false;
+    }
+  }
 
-export function injectTaskStore() {
-  return inject<TaskStore>('tasks')!;
+  async function update(id: string, updates: Partial<{ text: string; done: boolean }>) {
+    loading.value = true;
+    try {
+      const updatedTask = await $fetch<Task>(`/api/todos/${id}`, {
+        method: 'PUT',
+        body: updates,
+      });
+      const index = items.value.findIndex(t => t.id === id);
+      if (index !== -1) {
+        items.value[index] = updatedTask;
+        // Re-sort after updating
+        items.value.sort((a, b) => {
+          if (a.done !== b.done) {
+            return a.done ? 1 : -1;
+          }
+          return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+        });
+      }
+    }
+    finally {
+      loading.value = false;
+    }
+  }
+
+  async function toggleDone(id: string) {
+    const task = items.value.find(t => t.id === id);
+    if (task) {
+      await update(id, { done: !task.done });
+    }
+  }
+
+  function setEditing(task: Task) {
+    editingTask.value = { id: task.id, text: task.text };
+  }
+
+  function cancelEditing() {
+    editingTask.value = null;
+  }
+
+  async function saveEditing(text: string) {
+    if (editingTask.value) {
+      await update(editingTask.value.id, { text });
+      editingTask.value = null;
+    }
+  }
+
+  async function remove(id: string) {
+    loading.value = true;
+    try {
+      await $fetch(`/api/todos/${id}`, {
+        method: 'DELETE',
+      });
+      items.value = items.value.filter(t => t.id !== id);
+    }
+    finally {
+      loading.value = false;
+    }
+  }
+
+  return {
+    items,
+    loading,
+    editingTask,
+    load,
+    add,
+    update,
+    toggleDone,
+    setEditing,
+    cancelEditing,
+    saveEditing,
+    remove,
+  };
 }

--- a/server/api/todos.get.ts
+++ b/server/api/todos.get.ts
@@ -1,0 +1,9 @@
+import { defineEventHandler } from 'h3';
+
+import { useToDoStorage } from '~~/layers/to-do/server/services/storage';
+
+const storage = useToDoStorage();
+
+export default defineEventHandler(async () => {
+  return await storage.load();
+});

--- a/server/api/todos.post.ts
+++ b/server/api/todos.post.ts
@@ -1,0 +1,31 @@
+import { createError, defineEventHandler, readBody } from 'h3';
+
+import { useToDoStorage } from '~~/layers/to-do/server/services/storage';
+
+const storage = useToDoStorage();
+
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody<{ text: string }>(event, { strict: true });
+
+    if (!body.text || body.text.trim() === '') {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'text is required',
+      });
+    }
+
+    const todo = await storage.save(body);
+    event.node.res.statusCode = 201;
+    return todo;
+  }
+  catch (error) {
+    if (error instanceof Error && error.message === 'todo limit reached') {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'todo limit reached',
+      });
+    }
+    throw error;
+  }
+});

--- a/server/api/todos/[id].delete.ts
+++ b/server/api/todos/[id].delete.ts
@@ -1,0 +1,19 @@
+import { createError, defineEventHandler, getRouterParam } from 'h3';
+
+import { useToDoStorage } from '~~/layers/to-do/server/services/storage';
+
+const storage = useToDoStorage();
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id');
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'id is required',
+    });
+  }
+
+  await storage.remove(id);
+  event.node.res.statusCode = 204;
+});

--- a/server/api/todos/[id].put.ts
+++ b/server/api/todos/[id].put.ts
@@ -1,0 +1,32 @@
+import { createError, defineEventHandler, getRouterParam, readBody } from 'h3';
+
+import { useToDoStorage } from '~~/layers/to-do/server/services/storage';
+
+const storage = useToDoStorage();
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id');
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'id is required',
+    });
+  }
+
+  try {
+    const body = await readBody<{ text?: string; done?: boolean }>(event, { strict: true });
+
+    const todo = await storage.update(id, body);
+    return todo;
+  }
+  catch (error) {
+    if (error instanceof Error && error.message === 'todo not found') {
+      throw createError({
+        statusCode: 404,
+        statusMessage: 'todo not found',
+      });
+    }
+    throw error;
+  }
+});


### PR DESCRIPTION
Implements the to-do app plan from `docs/plans/2026-03-16-to-do-plan.md`. Migrates from in-memory class-based store to Supabase-backed persistence with composable pattern.

## Storage Layer
- `layers/to-do/server/services/storage.ts` - Supabase client wrapper using productivity schema
- Enforces 100-item limit with count check before insertion
- API routes: `GET /api/todos`, `POST /api/todos` (returns 409 on limit), `PUT /api/todos/:id`, `DELETE /api/todos/:id`

## Client Store
- Converts from class-based inject/provide pattern to composable `useTaskStore()`
- Reactive sync with server via `$fetch` 
- Auto-sorts items: pending first, then by `created_at`
- Edit mode state management with `editingTask` ref

## UI Components
**ToDoTaskForm**: Full-width input with dual create/edit mode. Shows Cancel button during edit. Enter submits, Esc cancels.

**ToDoTaskList**: Renders "Pending" and "Completed" sections with headings. Uses `task.id` as key. Edit/Delete buttons per item.

**Main page**: Loads tasks on mount via `onMounted()`

```typescript
// Old: class-based
export class TaskStore {
  items = reactive([...])
  add(task: string) { ... }
}

// New: composable with server sync
export function useTaskStore() {
  const items = ref<Task[]>([])
  async function add(text: string) {
    const newTask = await $fetch('/api/todos', { ... })
    items.value.push(newTask)
  }
  return { items, add, ... }
}
```

## Testing
9 unit tests covering CRUD operations, edit flow, and sorting behavior. All 64 tests passing.

## Database Schema
Requires `todos` table in productivity schema (see plan doc for SQL). Uses `gen_random_uuid()` for IDs.